### PR TITLE
Hello, I like your plugin, so I tried to use this with my current project, where I use ajax-solr. I needed the possibility to add handlers to the words (links) before the callback-function is called, so - perhaps its useful for some others, too. 

### DIFF
--- a/jqcloud/jqcloud-0.2.4.js
+++ b/jqcloud/jqcloud-0.2.4.js
@@ -92,10 +92,20 @@
 
         // Linearly map the original weight to a discrete scale from 1 to 10
         var weight = Math.round((word.weight - word_array[word_array.length - 1].weight)/(word_array[0].weight - word_array[word_array.length - 1].weight) * 9.0) + 1;
-
-        var inner_html = word.url !== undefined ? "<a href='" + encodeURI(word.url).replace(/'/g, "%27") + "'>" + word.text + "</a>" : word.text;
-        $this.append("<span id='" + word_id + "' class='w" + weight + random_class + "' title='" + (word.title || "") + "'>" + inner_html + "</span>");
-
+		
+		var outer_html = $('<span>').attr('id',word_id).attr('class','w' + weight).attr('title', word.title || word.text || '');
+        
+        if(word.handlers) {
+        	var inner_html = $('<a>').attr('href','#').text(word.text);
+        	for (var prop in word.handlers) {
+				$(inner_html).bind(prop, word.handlers[prop]);
+        	}  	
+        } else {
+        	var inner_html = word.url !== undefined ? "<a href='" + encodeURI(word.url).replace(/'/g, "%27") + "'>" + word.text + "</a>" : word.text;
+        }
+        
+        $this.append($(outer_html).append(inner_html));
+        
         // Search for the word span only once, and within the context of the container, for better performance
         var word_span = $(word_selector, $this);
 


### PR DESCRIPTION
you can now use handlers (click, mouseover...)

config looks like:

{
  text : facet,
  weight : count,
  url: '#',
  handlers: {
    click: myClickHandler,
    mouseover: function() {  }
  }
}
