### PR TITLE
Added support for passing data-X attributes via a 'data_attributes' option

### DIFF
--- a/src/jqcloud/jqcloud.js.erb
+++ b/src/jqcloud/jqcloud.js.erb
@@ -103,6 +103,11 @@
             word_span = $('<span>').attr('id',word_id).attr('class','w' + weight).addClass(random_class).attr('title', word.title || word.text || ''),
             inner_html;
 
+	// set data-X attributes if passed
+        if(word.data_attributes){
+ 	    $.each( word.data_attributes , function(i,v){ word_span.attr('data-'+i,v); } );
+	}
+
         // Append link if word.url attribute was set
         if (!!word.url) {
           inner_html = $('<a>').attr('href', encodeURI(word.url).replace(/'/g, "%27")).text(word.text);


### PR DESCRIPTION
Pass a 'data_attributes' parameter on the word and it will be rendered on the span, for example:

jQCloud( [
  {
    'text': 'Foo',
    'weight': 12345,
    'data_attributes': {
      'testing': 'this',
      'somekey': 'avalue'
    }
  },
  ...
]);

Would result in the following span:

<span data-testing="this" data-somekey="avalue" id="undefined_word_1" class="w10" ... >
