### PR TITLE
Added option to turn url encoding on and off

### DIFF
--- a/jqcloud/jqcloud-1.0.0.js
+++ b/jqcloud/jqcloud-1.0.0.js
@@ -26,7 +26,8 @@
         y: ((options && options.height) ? options.height : $this.height()) / 2.0
       },
       delayedMode: word_array.length > 50,
-      shape: false // It defaults to elliptic shape
+      shape: false, // It defaults to elliptic shape
+      encodeURI: true
     };
 
     options = $.extend(default_options, options || {});
@@ -115,7 +116,9 @@
           }
 
           // Extend link html options with defaults
-          word.link = $.extend(word.link, {href: encodeURI(word.link.href).replace(/'/g, "%27")});
+	  if (options.encodeURI){
+            word.link = $.extend(word.link, {href: encodeURI(word.link.href).replace(/'/g, "%27")});
+	  }
 
           inner_html = $('<a>').attr(word.link).text(word.text);
         } else {

--- a/test/core_tests.js
+++ b/test/core_tests.js
@@ -26,7 +26,29 @@ var some_words_with_same_weight = [
   {text: 'Ghi', weight: 1}
 ]
 
+$(function(){
+  var encoded_words = [
+    {text: "John's Bday", weight: 1, link: "/posts?tag=John%27s+Bday"}
+  ];
+  $("#container5").jQCloud(encoded_words, {
+    encodeURI: false,
+    afterCloudRender: function(){
+      test('Links render without encoding', function(){
+        equal($("#container5 span a").attr('href'),'/posts?tag=John%27s+Bday', 'If encodeURI is turned off');
+      });
+    }
+  });
+  $("#container6").jQCloud(encoded_words, {
+    afterCloudRender: function(){
+      test('Links render with encoding', function(){
+        equal($("#container6 span a").attr('href'),'/posts?tag=John%2527s+Bday', 'If encodeURI is turned off');
+      });
+    }
+  });
+});
+
 $(document).ready(function() {
+
   $("#container").jQCloud(some_words, {afterCloudRender: function() {
 
     test('Basic plugin functionality', function() {
@@ -106,6 +128,7 @@ $(document).ready(function() {
       });
     }
   });
+
   setTimeout(function(){
     test('Words do not render when delayedMode true and container is not visible',function(){
       ok(!$(".container4").is(':visible'), "Container is not visible");

--- a/test/index.html
+++ b/test/index.html
@@ -19,5 +19,7 @@
     <div id="container2" style="width: 400px; height: 300px; border: 1px solid #ccc; margin: 20px;"></div>
     <div class="container3" style="width: 400px; height: 300px; border: 1px solid #ccc; margin: 20px;"></div>
     <div class="container4" style="display:none; width: 400px; height: 300px; border: 1px solid #ccc; margin: 20px;"></div>
+    <div id="container5" style="width: 400px; height: 300px; border: 1px solid #ccc; margin: 20px;"></div>
+    <div id="container6" style="width: 400px; height: 300px; border: 1px solid #ccc; margin: 20px;"></div>
   </body>
 </html>


### PR DESCRIPTION
Rails url helpers escape special characters when creating urls, so when jQCloud escapes the url it double escapes it.

``` html
<script type="text/javascript" >
  var word_array = [{text: "John's Bday", weight: 1, link: "/posts?tag=John%27s+Bday"}]
</script>
```

Becomes...

``` html
<span id="example_word_1" class="w1">
  <a href="/posts?tag=John%2527s+Bday">John's Bday</a>
</span>
```

Which doesn't link correctly.
